### PR TITLE
Handle when base 64 system version string has a double slash in it

### DIFF
--- a/server/livecheck.py
+++ b/server/livecheck.py
@@ -69,25 +69,16 @@ def processCodeData(data):
 
     message, signature, certificate_without_envelope = components
 
-    message_parts = message.split("//")
-    if len(message_parts) != 3:
-        return None
-
-    version, header, fields_str = message_parts
-
-    if version != "1":
-        return None
+    v3_prefix = "1//lc//" # Live Check (legacy feature name)
+    v4_prefix = "1//shv1//" # Signed Hash Validation, version 1
 
     vxsuite_version = None
-
-    # Live Check (legacy feature name)
-    if header == "lc":
-        fields = fields_str.split("/")
+    if message.startswith(v3_prefix):
+        fields = message[len(v3_prefix):].split("/")
         if len(fields) == 3:
             vxsuite_version = "v3"
-    # Signed hash validation, version 1
-    elif header =="shv1":
-        fields = fields_str.split("#")
+    elif message.startswith(v4_prefix):
+        fields = message[len(v4_prefix):].split("#")
         if len(fields) == 4:
             vxsuite_version = "v4"
     if not vxsuite_version:


### PR DESCRIPTION
## Overview

We recently encountered a base 64 system version string with a double slash in it `//`. This tripped up our Signed Hash Validation parsing logic, which in one layer, splits on a double slash separator. While one option would be to change the separator to become impossible to find within a base 64 string, this specific layer really just involves a prefixed message. So I've instead opted to change the parsing rather than the separator. Changing the separator would require us to build even more backwards compatibility logic into the SHV web app, for v4.0.1 vs. v4.0.2+. This layer is also shared with other VxSuite signing operations, so even if we were to find a separator that wouldn't show up in SHV content, there's ultimately no separator that's guaranteed to not show up in this layer's content.

## Testing

- [x] Tested manually with QR code content that was previously failing to parse