### PR TITLE
add Airtable integration to log SHV events

### DIFF
--- a/server/airtable.py
+++ b/server/airtable.py
@@ -1,0 +1,40 @@
+import requests
+
+AIRTABLE_API_BASE = "https://api.airtable.com/v0"
+SHV_EVENTS_TABLE = "SHV Events"
+
+
+def log_to_airtable(api_key, base_id, success_result):
+    """
+    Creates a record in the SHV Events table.
+    Returns {"success": True} or {"success": False, "error": "..."}
+    """
+    url = f"{AIRTABLE_API_BASE}/{base_id}/{SHV_EVENTS_TABLE}"
+
+    try:
+        response = requests.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json"
+            },
+            json={
+                "fields": {
+                    "Machine ID": success_result.get("machine_id"),
+                    "Election ID": success_result.get("election_id"),
+                    "System Hash": success_result.get("system_hash"),
+                    "Version": success_result.get("software_version"),
+                    "Timestamp": success_result.get("timestamp")
+                }
+            }
+        )
+
+        if response.status_code in (200, 201):
+            return {"success": True}
+        else:
+            print(f"Airtable: Failed to create record: {response.status_code}, {response.text}")
+            return {"success": False, "error": f"API error {response.status_code}"}
+
+    except Exception as e:
+        print(f"Airtable: Exception: {e}")
+        return {"success": False, "error": str(e)}

--- a/server/airtable.py
+++ b/server/airtable.py
@@ -4,7 +4,7 @@ AIRTABLE_API_BASE = "https://api.airtable.com/v0"
 SHV_EVENTS_TABLE = "SHV Events"
 
 
-def log_to_airtable(api_key, base_id, success_result):
+def log_success_to_airtable(api_key, base_id, success_result):
     """
     Creates a record in the SHV Events table.
     Returns {"success": True} or {"success": False, "error": "..."}

--- a/server/app.py
+++ b/server/app.py
@@ -3,9 +3,12 @@ from flask import Flask, send_from_directory, request
 
 from .livecheck import processCodeData
 from .slack import log_success_to_slack
+from .airtable import log_to_airtable
 
 STATIC_FOLDER= os.path.join(os.path.dirname(os.path.abspath(__file__)), "../dist")
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
+AIRTABLE_API_KEY = os.environ.get("AIRTABLE_API_KEY", "")
+AIRTABLE_BASE_ID = os.environ.get("AIRTABLE_BASE_ID", "")
 
 app = Flask("livecheck", static_folder=None)
 
@@ -15,8 +18,11 @@ def check():
     livecheck_data = request.get_data().decode('utf-8')
     result = processCodeData(livecheck_data)
     if result:
+        airtable_result = None
+        if AIRTABLE_API_KEY and AIRTABLE_BASE_ID:
+            airtable_result = log_to_airtable(AIRTABLE_API_KEY, AIRTABLE_BASE_ID, result)
         if SLACK_WEBHOOK_URL:
-            log_success_to_slack(SLACK_WEBHOOK_URL, result)
+            log_success_to_slack(SLACK_WEBHOOK_URL, result, airtable_result)
         return result, 200
     else:
         return "error", 401

--- a/server/app.py
+++ b/server/app.py
@@ -3,7 +3,7 @@ from flask import Flask, send_from_directory, request
 
 from .livecheck import processCodeData
 from .slack import log_success_to_slack
-from .airtable import log_to_airtable
+from .airtable import log_success_to_airtable
 
 STATIC_FOLDER= os.path.join(os.path.dirname(os.path.abspath(__file__)), "../dist")
 SLACK_WEBHOOK_URL = os.environ.get("SLACK_WEBHOOK_URL", "")
@@ -20,7 +20,7 @@ def check():
     if result:
         airtable_result = None
         if AIRTABLE_API_KEY and AIRTABLE_BASE_ID:
-            airtable_result = log_to_airtable(AIRTABLE_API_KEY, AIRTABLE_BASE_ID, result)
+            airtable_result = log_success_to_airtable(AIRTABLE_API_KEY, AIRTABLE_BASE_ID, result)
         if SLACK_WEBHOOK_URL:
             log_success_to_slack(SLACK_WEBHOOK_URL, result, airtable_result)
         return result, 200

--- a/server/slack.py
+++ b/server/slack.py
@@ -6,16 +6,22 @@ def markdown(text):
 def log_success_to_slack(
     slack_webhook_url,
     success_result,
+    airtable_result=None,
 ):
+    if airtable_result and not airtable_result["success"]:
+        header_text = ":warning: Scan succeeded, but Airtable integration failed :warning:"
+    else:
+        header_text = ":white_check_mark: Scan succeeded"
+
     response = requests.post(
         slack_webhook_url,
         headers={"Content-Type": "application/json"},
         json={
-            "text": "Scan succeeded",
+            "text": header_text,
             "blocks": [
                 {
                     "type": "section",
-                    "text": markdown("*Scan succeeded*"),
+                    "text": markdown(f"*{header_text}*"),
                 },
                 {
                     "type": "context",


### PR DESCRIPTION
On successful live check, creates a record in the Airtable "SHV Events" table with Machine ID, Election ID, System Hash, Version, and Timestamp fields.

To keep `livecheck-web`'s job simple, it's only responsibility is to create a record in Airtable with all the information in the live check, avoiding any complicated use of the API. If the Airtable API hit was unsuccessful, it adds that information to the Slack message. I added a warning emoji for that case so for consistency I added an emoji to the success case too.

On the Airtable side, the API access token is only set up with access to a dedicated base, "SHV Events". The main base has a synced version of this table. This allows us to scope write access to only SHV events. When an SHV event is created, an automation runs that tries to find the machine and update its code version and "Last Reported System Hash". 

I tested the happy path in dev (I deployed branch to staging and tested from dev on my laptop). I haven't tested the case where the Airtable API fails (when called from `livecheck`) or where the machine isn't found (in Airtable), but those both seem like pretty straightforward logic so I'm unconcerned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)