### PR TITLE
Update Slack message text for clarity

### DIFF
--- a/server/slack.py
+++ b/server/slack.py
@@ -9,9 +9,9 @@ def log_success_to_slack(
     airtable_result=None,
 ):
     if airtable_result and not airtable_result["success"]:
-        header_text = ":warning: Scan succeeded, but Airtable integration failed :warning:"
+        header_text = ":warning: Validation succeeded, but Airtable integration failed :warning:"
     else:
-        header_text = ":white_check_mark: Scan succeeded"
+        header_text = ":white_check_mark: Validation succeeded"
 
     response = requests.post(
         slack_webhook_url,


### PR DESCRIPTION
"Scan succeeded" might be confused with actually scanning a ballot. Switching to "Validation succeeded" for clarity.